### PR TITLE
Set static size of label to match design 

### DIFF
--- a/CloudOnMobile/Base/UIView+AutoLayout.swift
+++ b/CloudOnMobile/Base/UIView+AutoLayout.swift
@@ -26,7 +26,7 @@ public extension UIView {
 
     /// Describes edges that are equal to superview edges
     /// - Returns: created constraints
-    func equalEdges() -> [ConstraintConstructor] {
+    @discardableResult func equalEdges() -> [ConstraintConstructor] {
         [
             equal(.top),
             equal(.bottom),

--- a/CloudOnMobile/Modules/Main/MainViewController.swift
+++ b/CloudOnMobile/Modules/Main/MainViewController.swift
@@ -92,6 +92,11 @@ private extension MainViewController {
         getCodeButton.addConstraints { [
             $0.equalConstant(.height, 56)
         ] }
+
+        codeValueLabel.addConstraints { [
+            $0.equal(.leading, constant: 16),
+            $0.equal(.trailing, constant: -16)
+        ] }
     }
 
     @objc func getCodeButtonTapped() {
@@ -100,8 +105,10 @@ private extension MainViewController {
             switch result {
             case let .success(code):
                 codeValueLabel.text = code
-            case let .failure(error):
-                codeValueLabel.text = error.localizedDescription
+                codeValueLabel.addCharactersSpacing(value: 26)
+            case .failure:
+                /// - TODO: Handle error
+                break
             }
         }
     }


### PR DESCRIPTION
## Task description 
Letters should not move after assigning them to code label.

With code:

![code](https://user-images.githubusercontent.com/57398986/148417393-52352b72-1196-460d-91e3-760df3960e77.png)

With no value: 
![noValue](https://user-images.githubusercontent.com/57398986/148417408-d18f2aba-be1a-4f63-ba0d-eca32bc987cc.png)

