### PR TITLE
Enable SSL Pinning

### DIFF
--- a/CloudOnMobile/CommandManager.swift
+++ b/CloudOnMobile/CommandManager.swift
@@ -39,12 +39,13 @@ final class CommandManager {
 
     private let ip: String
 
-    private let port: Int = 9293
+    private let port: Int
 
     private let documentsDirectory: URL
 
-    init(url: String) {
+    init(url: String, port:Int) {
         ip = url
+      self.port = port
         initSharedCore()
         let fileMngr = FileManager.default
         documentsDirectory = fileMngr.urls(for: .documentDirectory, in: .userDomainMask)[0]

--- a/CloudOnMobile/Configuration/AppSchemeProperties.swift
+++ b/CloudOnMobile/Configuration/AppSchemeProperties.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol AppSchemeProperties {
     /// Backend host for the app.
     var host: String { get }
+    var port: Int { get }
 }
 
 /// Structure describes properties dependent on app scheme.
@@ -17,17 +18,21 @@ struct DefaultAppSchemeProperties: AppSchemeProperties {
     // MARK: - AppSchemeProperties
 
     let host: String
+    let port: Int
 
     // MARK: - Initialization
 
     /// Initialize app properties based on scheme.
     init() {
         #if DEVELOPMENT
-            host = "192.168.50.10"
+            host = "cloudon.cc"
+            port = 9283
         #elseif STAGING
-            host = "192.168.50.10"
+            host = "cloudon.cc"
+            port = 9283
         #elseif PRODUCTION
             host = "cloudon.cc"
+            port = 9293
         #endif
     }
 }

--- a/CloudOnMobile/Configuration/AppSchemeProperties.swift
+++ b/CloudOnMobile/Configuration/AppSchemeProperties.swift
@@ -10,6 +10,8 @@ import Foundation
 protocol AppSchemeProperties {
     /// Backend host for the app.
     var host: String { get }
+
+    /// Backend port for the app.
     var port: Int { get }
 }
 

--- a/CloudOnMobile/FlowControllers/Main/MainDependencyContainer.swift
+++ b/CloudOnMobile/FlowControllers/Main/MainDependencyContainer.swift
@@ -15,7 +15,7 @@ protocol MainDependencyContainer {
 
 final class DefaultMainDependencyContainer: MainDependencyContainer {
     lazy var commandManager: CommandManager = {
-        CommandManager(url: appSchemeProperties.host)
+      CommandManager(url: appSchemeProperties.host, port: appSchemeProperties.port)
     }()
 
     // MARK: - Private

--- a/CloudOnMobile/Networking/CommandManager.swift
+++ b/CloudOnMobile/Networking/CommandManager.swift
@@ -45,9 +45,9 @@ final class CommandManager {
 
     private let documentsDirectory: URL
 
-    init(url: String, port:Int) {
+    init(url: String, port: Int) {
         ip = url
-      self.port = port
+        self.port = port
         initSharedCore()
         let fileMngr = FileManager.default
         documentsDirectory = fileMngr.urls(for: .documentDirectory, in: .userDomainMask)[0]


### PR DESCRIPTION
SSL Pinning takes place inside core to make it more secure. There is also a new staging server on port 9283.

I set both `Development` and `Staging` servers to cloudon.cc:92**8**3.
`Production` is at cloudon.cc:92**9**3.

The `Development` scheme will point to a localhost instance in the future once it's easy to run locally. For now let's try to use the Staging server for development.